### PR TITLE
added cyanogenmod as a remote

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -14,6 +14,10 @@
   <remote  name="omnirom"
            review="gerrit.omnirom.org"
            fetch="https://github.com/omnirom" />
+           
+  <remote  name="CyanogenMod"
+           fetch="https://github.com/CyanogenMod"
+           review="review.cyanogenmod.org" />
 
   <default revision="refs/tags/android-4.4.1_r1"
            remote="aosp"


### PR DESCRIPTION
packages/apps/SamsungServiceMode is fetched from CyanogenMod remote

else repo sync ends with this:
fatal: remote CyanogenMod not defined in omni-4.4/.repo/manifest.xml
